### PR TITLE
Add Martin Florian back to Splice

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -252,6 +252,7 @@ teams:
   - waynecollier-da
   members:
   - canton-network-da
+  - martinflorian-da
   - moritzkiefer-da
   - ray-roestenburg-da
 - name: weaver-admins


### PR DESCRIPTION
Martin Florian, a team lead at DA, got dropped in https://github.com/hyperledger-labs/governance/pull/102, let's add him back please.