### PR TITLE
promote DA automation user

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -288,11 +288,11 @@ teams:
   - martinflorian-da
   - moritzkiefer-da
   - ray-roestenburg-da
+  - canton-network-da
 - name: splice-contributors
   maintainers:
   - waynecollier-da
   members:
-  - canton-network-da
   - meiersi-da
   - rautenrieth-da
   - stephencompall-DA


### PR DESCRIPTION
Required in order for it to register the self-hosted runners