### PR TITLE
Add matteo to wallet kernel contributors

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -318,6 +318,7 @@ teams:
   - alexmatson-da
   - rukmini-basu-da
   - alexgraham-da
+  - matteolimberto-da
 - name: weaver-admins
   maintainers:
   - VRamakrishna


### PR DESCRIPTION
Added [matteolimberto](https://github.com/matteolimberto-da) as a contributor for the splice wallet kernel