### PR TITLE
Add nosoypoot to learning-tokens-maintainers; promote AlfonsoGovela to maintainer of both learning-tokens teams

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -118,11 +118,11 @@ teams:
 - name: learning-tokens-maintainers
   maintainers:
   - TanjinAlam
-  - nosoypoot
   members:
   - noemi128
   - AlfonsoGovela 
   - NeoZ666
+  - nosoypoot
 - name: learning-tokens-mentees
   maintainers:
   - noemi128

--- a/config.yaml
+++ b/config.yaml
@@ -118,6 +118,7 @@ teams:
 - name: learning-tokens-maintainers
   maintainers:
   - TanjinAlam
+  - nosoypoot
   members:
   - noemi128
   - AlfonsoGovela 

--- a/config.yaml
+++ b/config.yaml
@@ -118,14 +118,15 @@ teams:
 - name: learning-tokens-maintainers
   maintainers:
   - TanjinAlam
+  - AlfonsoGovela
   members:
   - noemi128
-  - AlfonsoGovela 
   - NeoZ666
   - nosoypoot
 - name: learning-tokens-mentees
   maintainers:
   - noemi128
+  - AlfonsoGovela
   members:
   - Ankita0112
   - AviraL0013


### PR DESCRIPTION
Two related changes to the Learning Tokens lab teams.

## 1. Add @nosoypoot to `learning-tokens-maintainers` (as a member)

Requested by @ryjones. I serve as technical mentor for the lab.

Not having access has been blocking configuration work. Two examples from this week: enabling GitHub Pages and setting a custom domain both had to be done by someone else, and the website PR ([hyperledger-labs/learning-tokens#216](https://github.com/hyperledger-labs/learning-tokens/pull/216)) is waiting on a CODEOWNER approval.

The team already carries `maintain` on the `learning-tokens` repo, so `members` is enough to unblock that.

I first proposed adding myself under `maintainers`; CLOWarden correctly rejected it, since org membership is a prerequisite and I am not an org member yet. Corrected to `members`.

## 2. Promote @AlfonsoGovela to maintainer of both teams

Requested by @AlfonsoGovela.

He is listed as an Initial Committer of the lab in its [LFDT entry](https://lf-decentralized-trust-labs.github.io/labs/approved/learning-tokens.html), actively reviews and approves pull requests, and mentors the current cohort.

Neither team has an active maintainer today: `learning-tokens-maintainers` lists only @TanjinAlam, who has had no activity in the lab since December 2024, and this leaves team administration unattended. Promoting @AlfonsoGovela addresses that.

This moves him from `members` to `maintainers` on `learning-tokens-maintainers`, and adds him as a maintainer of `learning-tokens-mentees` alongside @noemi128.

## No other membership changes

To be explicit, since this PR touches team roles: **no one else's role changes.** @NeoZ666 and @noemi128 stay exactly as they are on `learning-tokens-maintainers`, and the `learning-tokens-mentees` member list is untouched. The full set of changes is the four lines CLOWarden reports below.

Happy to split this into a separate PR if the stewards would rather review the two changes independently.

All commits are DCO signed off.